### PR TITLE
입력 전처리 개선

### DIFF
--- a/src/mapreduce.cpp
+++ b/src/mapreduce.cpp
@@ -47,8 +47,9 @@ class WordCountMapper : public IMapper {
 public:
     void Map(const std::string& key, const std::string& value) override {
         std::string str = value;
-
-        std::replace_if(str.begin(), str.end(), [](unsigned char c) { return !std::isalpha(c); }, ' ');
+        std::transform(str.cbegin(), str.cend(), str.begin(), [](unsigned char c) {
+            return std::isalpha(c) ? std::tolower(c) : ' ';
+        });
         std::istringstream stream(str);
         std::string word;
 


### PR DESCRIPTION
## 변경사항
- 매핑 전에 키워드를 소문자로 변환하도록 처리

## 비고사항
키워드를 대소문자를 처리하지 않으면 `Bread`와 `bread`를 다른 키워드로 인식함.