### PR TITLE
병렬연산 최적화

### DIFF
--- a/src_for_visualstudio/DatabaseSystemProject/DatabaseSystemProject/DatabaseSystemProject.vcxproj
+++ b/src_for_visualstudio/DatabaseSystemProject/DatabaseSystemProject/DatabaseSystemProject.vcxproj
@@ -48,7 +48,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>

--- a/src_for_visualstudio/DatabaseSystemProject/DatabaseSystemProject/MapReduce.hpp
+++ b/src_for_visualstudio/DatabaseSystemProject/DatabaseSystemProject/MapReduce.hpp
@@ -12,37 +12,6 @@ private:
     std::mutex mtx;
 };
 
-//template <typename Key, typename T>
-//class ConcurrentMap {
-//public:
-//    typedef typename std::unordered_map<Key, T>::iterator iter;
-//
-//    /**
-//     * Get a value associated with the key
-//     */
-//    T get(Key key);
-//
-//    /**
-//     * Adds new entry to this map.
-//     */
-//    void put(Key key, T value);
-//
-//    /**
-//     * Thread safety is not guaranteed.
-//     * @return iterator of first element
-//     */
-//    typename iter begin();
-//
-//    /**
-//     * Thread safety is not guaranteed.
-//     * @return iterator of last element
-//     */
-//    typename iter end();
-//private:
-//    std::unordered_map<Key, T> map;
-//    std::mutex mtx;
-//};
-
 class IMapper {
 public:
     virtual ~IMapper() {}

--- a/src_for_visualstudio/DatabaseSystemProject/DatabaseSystemProject/Utility.cpp
+++ b/src_for_visualstudio/DatabaseSystemProject/DatabaseSystemProject/Utility.cpp
@@ -30,7 +30,6 @@ std::deque<std::string> getFileLines(const std::wstring& filename) {
     return data;
 }
 
-// deprecated
 std::string wideStringToString(const std::wstring& wstr) {
     if (wstr.empty()) return std::string();
 
@@ -75,7 +74,7 @@ std::string toBytesFormat(size_t bytes) {
     return std::string(buf);
 }
 
-std::string toTimeFormat(long milliseconds) {
+std::string toTimeFormat(time_t milliseconds) {
     static const size_t BUF_SIZE = 200;
 
     if (milliseconds < 10000) {
@@ -84,7 +83,7 @@ std::string toTimeFormat(long milliseconds) {
     }
 
     char* buf = (char*) malloc(sizeof(char) * BUF_SIZE);
-    int sec = milliseconds / 1000;
+    int sec = static_cast<int>(milliseconds / 1000);
     int min = sec / 60;
     int hr = min / 60;
     min -= hr * 60;
@@ -103,7 +102,7 @@ std::string toTimeFormat(long milliseconds) {
     return std::string(buf);
 }
 
-bool writeFile(std::ofstream &file, const std::string& filename, std::ios::openmode mode) {
+void writeFile(std::ofstream &file, const std::string& filename, std::ios::openmode mode) {
     //fileMutex.lock();
     //int tmpCount = fileCount + 1;
     //fileMutex.unlock();
@@ -113,17 +112,7 @@ bool writeFile(std::ofstream &file, const std::string& filename, std::ios::openm
     //}
 
     file.open(filename, mode);
-
-    if (file.is_open()) {
-        //fileMutex.lock();
-        //++fileCount;
-        //fileMutex.unlock();
-        return true;
-    }
-    else {
-        throw std::system_error(EFAULT, std::iostream_category(), "Failed to write file");
-        return false;
-    }
+    file.exceptions(std::ios::failbit | std::ifstream::badbit);
 }
 
 void closeFile(std::ofstream &file) {

--- a/src_for_visualstudio/DatabaseSystemProject/DatabaseSystemProject/Utility.hpp
+++ b/src_for_visualstudio/DatabaseSystemProject/DatabaseSystemProject/Utility.hpp
@@ -10,8 +10,8 @@ void printProgress(long counter, long target, bool init);
 
 std::string toBytesFormat(size_t bytes);
 
-std::string toTimeFormat(long milliseconds);
+std::string toTimeFormat(time_t milliseconds);
 
-bool writeFile(std::ofstream &file, const std::string& filename, std::ios::openmode mode);
+void writeFile(std::ofstream &file, const std::string& filename, std::ios::openmode mode);
 
 void closeFile(std::ofstream &file);

--- a/src_for_visualstudio/DatabaseSystemProject/DatabaseSystemProject/WordCount.cpp
+++ b/src_for_visualstudio/DatabaseSystemProject/DatabaseSystemProject/WordCount.cpp
@@ -20,6 +20,8 @@ WordCountMapper::WordCountMapper(bool inplace) {
 }
 
 void WordCountMapper::map(const std::string& key, std::string& value) {
+    static std::mutex mtx;
+
     std::transform(value.cbegin(), value.cend(), value.begin(), [](unsigned char c) {
         // Preprocess input keywords
         return std::isalpha(c) ? std::tolower(c) : ' ';
@@ -45,25 +47,21 @@ void WordCountMapper::map(const std::string& key, std::string& value) {
     // A file storing intermediate mapping result
     std::string filename = getRunFilename(std::to_string(0), key);
     std::ofstream outputFile;
-    static std::mutex mtx;
+    std::lock_guard<std::mutex> lock(mtx);
+    
+    writeFile(outputFile, filename, std::ios::app | std::ios::out);
 
-    mtx.lock();
-    bool open = writeFile(outputFile, filename, std::ios::app | std::ios::out);
-    mtx.unlock();
+    //while (!open) {
+    //    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    //    mtx.lock();
+    //    open = writeFile(outputFile, filename, std::ios::app | std::ios::out);
+    //    std::cout << "Attempting to re-open file: " << filename << std::endl;
+    //    mtx.unlock();
+    //}
 
-    while (!open) {
-        std::this_thread::sleep_for(std::chrono::milliseconds(100));
-        mtx.lock();
-        open = writeFile(outputFile, filename, std::ios::app | std::ios::out);
-        std::cout << "Attempting to re-open file: " << filename << std::endl;
-        mtx.unlock();
-    }
-
-    mtx.lock();
     for (auto pair : map) {
         outputFile << pair.first << ": " << pair.second << '\n';
     }
-    mtx.unlock();
 
     closeFile(outputFile);
 }
@@ -72,7 +70,10 @@ ConcurrentQueue<std::pair<std::string, int>>& WordCountMapper::getGlobalQueue() 
     return globalQueue;
 }
 
-WordCountReducer::WordCountReducer(const std::string& filename) : outputFile(filename) {}
+WordCountReducer::WordCountReducer(const std::string& filename) {
+    outputFile.open(filename);
+    outputFile.exceptions(std::ios::failbit | std::ifstream::badbit);
+}
 
 WordCountReducer::~WordCountReducer() {
     outputFile.close();
@@ -87,26 +88,48 @@ void WordCountReducer::reduce(ConcurrentQueue<std::pair<std::string, int>>& queu
 }
 
 void WordCountReducer::reduce(std::vector<std::string> runs) {
+    static std::mutex mtx_file;
+    static std::mutex mtx_map;
+
     for (std::string filename : runs) {
-        std::ifstream file(filename);
+        std::ifstream file;
         std::string line;
 
-        while (std::getline(file, line)) {
+        mtx_file.lock();
+        file.open(filename);
+        mtx_file.unlock();
+
+        while (true) {
+            mtx_file.lock();
+            bool eol = !std::getline(file, line);
+            mtx_file.unlock();
+
+            if (eol) break;
+
             std::string token(": ");
             auto i = line.find(token);
             std::string key = line.substr(0, i);
             int value = std::stoi(line.substr(i + token.length()));
+
+            mtx_map.lock();
             results[key] += value;
+            mtx_map.unlock();
         }
+
+        mtx_file.lock();
         file.close();
+        mtx_file.unlock();
     }
 }
 
 void WordCountReducer::writeRun() {
+    static std::mutex mtx;
     std::vector<std::pair<std::string, int>> resultsVec(results.begin(), results.end());
     std::sort(resultsVec.begin(), resultsVec.end(), [](const std::pair<std::string, int>& a, const std::pair<std::string, int>& b) {
         return a.second > b.second;
     });
+
+    std::lock_guard<std::mutex> lock(mtx);
 
     for (const auto& pair : resultsVec) {
         outputFile << pair.first << ": " << pair.second << std::endl;
@@ -118,11 +141,106 @@ std::string getRunFilename(const std::string& step, const std::string& index) {
     return filename;
 }
 
+void mapRoutine(long maps, int batch, long& b, std::deque<std::string>& lines, WordCountMapper &mapper) {
+    static std::mutex mtx_lines;
+    static std::mutex mtx_counters;
+    std::string key;
+
+    while (true) {
+        if (b >= maps) break;
+
+        mtx_counters.lock();
+        key = std::to_string(b);
+        ++b;
+        printProgress(b, maps, false);
+        mtx_counters.unlock();
+
+        std::string filename = getRunFilename(std::to_string(0), key);
+        std::string value;
+
+        // ensure that new file doesn't overlap with existing one
+        remove(filename.c_str());
+
+        // combine lines into single string
+        for (int j = 0; j < batch; ++j) {
+            mtx_lines.lock();
+            if (lines.empty()) {
+                mtx_lines.unlock();
+                break;
+            }
+            value.append(lines.front()).append(" ");
+            lines.pop_front();
+            mtx_lines.unlock();
+            //value.append(lines[i + j]).append(" ");
+        }
+
+        // map lines in batch
+        mapper.map(key, value);
+    }
+}
+
+void mergeRoutine(int m, size_t output, size_t &mx, int &in, int &out, const std::string &i_key, const std::string &o_key) {
+    static std::mutex mtx_mx;
+    static std::mutex mtx_in;
+    static std::mutex mtx_out;
+    static std::mutex mtx_file;
+    
+    while (true) {
+        std::vector<std::string> files;
+        bool complete;
+
+        mtx_mx.lock();
+        complete = (mx < 1);
+        mx = complete ? 0 : --mx;
+        mtx_mx.unlock();
+
+        if (complete) break;
+
+        for (int j = 0; j < m; j++) {
+            std::string r_key = std::to_string(in + 1);
+            std::string filename = getRunFilename(i_key, r_key);
+
+            mtx_file.lock();
+            bool fileExists = fs::exists(filename);
+            mtx_file.unlock();
+
+            mtx_in.lock();
+            ++in;
+            mtx_in.unlock();
+
+            if (fileExists) {
+                files.push_back(filename);
+            }
+            else {
+                throw std::runtime_error("File not exist: " + filename);
+            }
+        }
+
+        mtx_out.lock();
+        ++out;
+        mtx_out.unlock();
+
+        std::string r_key = std::to_string(out);
+        std::string filename;
+
+        if (output > 1) {
+            filename = getRunFilename(o_key, r_key);
+        }
+        else {
+            filename = "output.txt";
+        }
+
+        WordCountReducer reducer(filename);
+        reducer.reduce(files);
+        reducer.writeRun();
+    }
+}
+
 void countWords(std::deque<std::string>& lines, bool inplace, int m, int batch) {
     WordCountMapper mapper(inplace);
-    long size = static_cast<double>(lines.size());
+    long maps = ceil((double) lines.size() / batch); // number of mappings required
     long b = 0;        // batch index
-    long counter = 0;  // number of lines processed
+    //long counter = 0;  // number of lines processed
     std::vector<std::thread> mapThreads;
     std::mutex mtx;
 
@@ -131,48 +249,32 @@ void countWords(std::deque<std::string>& lines, bool inplace, int m, int batch) 
     fs::create_directory(tmpPath);
 
     std::cout << "Mapping words...";
-    printProgress(0, size, true);
+    printProgress(0, maps, true);
 
-    for (int i = 0; (i + batch - 1) < size; i += batch) {
-        mapThreads.emplace_back([i, b, size, batch, &counter, &lines, &mtx, &mapper]() {
+    //for (int i = 0; (i + batch - 1) < size; i += batch) {
+    unsigned int core = std::thread::hardware_concurrency();
+    core = (core > 4) ? core : 4;
+
+    for (int i = 0; i < core; ++i) {
+        mapThreads.emplace_back([maps, batch, &b, &lines, &mapper]() {
             try {
-                std::string key = std::to_string(b);
-                std::string filename = getRunFilename(std::to_string(0), key);
-                std::string value;
-
-                // ensure that new file doesn't overlap with existing one
-                remove(filename.c_str());
-
-                // combine lines into single string
-                for (int j = 0; j < batch; ++j) {
-                    mtx.lock();
-                    value.append(lines.front()).append(" ");
-                    lines.pop_front();
-                    mtx.unlock();
-                    //value.append(lines[i + j]).append(" ");
-                }
-
-                // map lines in batch
-                mapper.map(key, value);
-
-                // critical section
-                mtx.lock();
-                counter += batch;
-                printProgress(counter, size, false);
-                mtx.unlock();
+                mapRoutine(maps, batch, b, lines, mapper);
             }
             catch (const std::system_error& e) {
-                std::clog << e.what() << " (" << e.code() << ")" << std::endl;
+                std::cout << e.what() << " (" << e.code() << ")" << std::endl;
+            }
+            catch (const std::ios_base::failure& e) {
+                std::cout << e.what() << '\n';
             }
             catch (const std::exception& e) {
-                std::clog << e.what() << std::endl;
+                std::cout << e.what() << std::endl;
             }
             catch (...) {
-                std::cout << "Unknown exception!" << std::endl;
+                char message[200];
+                strerror_s(message, sizeof(message), errno);
+                std::cerr << "Error: " << message << std::endl;
             }
         });
-
-        ++b;
     }
 
     for (auto& thread : mapThreads) {
@@ -181,13 +283,13 @@ void countWords(std::deque<std::string>& lines, bool inplace, int m, int batch) 
 
     // last batch is always incomplete
     // if size is not divisible by batch
-    if (size % batch > 0) {
-        for (int i = size - (size % batch); i < size; ++i) {
-            mapper.map(std::to_string(b), lines.front());
-            lines.pop_front();
-            printProgress(i + 1, size, false);
-        }
-    }
+    //if (size % batch > 0) {
+    //    for (int i = size - (size % batch); i < size; ++i) {
+    //        mapper.map(std::to_string(b), lines.front());
+    //        lines.pop_front();
+    //        printProgress(i + 1, size, false);
+    //    }
+    //}
 
     std::cout << std::endl;
 
@@ -204,13 +306,11 @@ void countWords(std::deque<std::string>& lines, bool inplace, int m, int batch) 
     int in = -1;   // input run index
     int out = -1;  // output run index
     int step = 0;  // phase of merge
-    size_t runs = b + 1;         // number of input
+    size_t runs = b;             // number of input
     size_t mx = runs / m;        // number of runs to be merged
     size_t rem = runs % m;       // number of runs remaining (not to be merged)
     size_t output = mx + rem;    // number of output
     std::string i_key = std::to_string(step);
-    std::mutex mtx_in;
-    std::mutex mtx_out;
 
     // repeat merge until we get single run
     while (runs > 1) {
@@ -226,47 +326,31 @@ void countWords(std::deque<std::string>& lines, bool inplace, int m, int batch) 
         ++step;
         std::string o_key = std::to_string(step);
         size_t mem = Profiler::getInstance()->getAllocatedMemory();
-        std::cout << '[' << step << "]\t" << m << "-way merge : "
+        std::cout << '[' << step << "] " << m << "-way merge / "
             << runs << " runs, " << output << " output, " << toBytesFormat(mem) << std::endl;
 
         // merge runs in parallel tasks
-        for (int i = 0; i < mx; ++i) {
-            threads.emplace_back([m, i_key, o_key, output, &in, &out, &mtx_in, &mtx_out]() {
-                std::vector<std::string> files;
-
-                for (int j = 0; j < m; j++) {
-                    std::string r_key = std::to_string(in + 1);
-                    std::string filename = getRunFilename(i_key, r_key);
-                    std::ifstream file(filename);
-
-                    if (!file.is_open()) {
-                        return;
-                    }
-
-                    files.push_back(filename);
-
-                    mtx_in.lock();
-                    ++in;
-                    mtx_in.unlock();
+        //for (int i = 0; i < mx; ++i) {
+        for (int i = 0; i < core; ++i) {
+            threads.emplace_back([m, output, &mx, &in, &out, &i_key, &o_key]() {
+                try {
+                    mergeRoutine(m, output, mx, in, out, i_key, o_key);
                 }
-
-                mtx_out.lock();
-                ++out;
-                mtx_out.unlock();
-
-                std::string r_key = std::to_string(out);
-                std::string filename;
-
-                if (output > 1) {
-                    filename = getRunFilename(o_key, r_key);
+                catch (const std::system_error& e) {
+                    std::cout << e.what() << " (" << e.code() << ")" << std::endl;
                 }
-                else {
-                    filename = "output.txt";
+                catch (const std::ios_base::failure& e) {
+                    std::cout << e.what() << '\n';
                 }
-
-                WordCountReducer reducer(filename);
-                reducer.reduce(files);
-                reducer.writeRun();
+                catch (const std::exception& e) {
+                    std::cout << e.what() << std::endl;
+                }
+                catch (...) {
+                    char message[200];
+                    strerror_s(message, sizeof(message), errno);
+                    std::cout << "Error: " << message << std::endl;
+                    return;
+                }
             });
         }
 
@@ -283,7 +367,7 @@ void countWords(std::deque<std::string>& lines, bool inplace, int m, int batch) 
             std::ifstream i_file(i_filename);
 
             if (!i_file.is_open()) {
-                return;
+                throw std::system_error(EFAULT, std::iostream_category(), "Failed to open: " + i_filename);
             }
 
             ++out;
@@ -294,7 +378,7 @@ void countWords(std::deque<std::string>& lines, bool inplace, int m, int batch) 
 
             if (!o_file.is_open()) {
                 i_file.close();
-                return;
+                throw std::system_error(EFAULT, std::iostream_category(), "Failed to open: " + o_filename);
             }
 
             while (std::getline(i_file, line)) {

--- a/src_for_visualstudio/DatabaseSystemProject/DatabaseSystemProject/WordCount.cpp
+++ b/src_for_visualstudio/DatabaseSystemProject/DatabaseSystemProject/WordCount.cpp
@@ -238,7 +238,7 @@ void mergeRoutine(int m, size_t output, size_t &mx, int &in, int &out, const std
 
 void countWords(std::deque<std::string>& lines, bool inplace, int m, int batch) {
     WordCountMapper mapper(inplace);
-    long maps = ceil((double) lines.size() / batch); // number of mappings required
+    long maps = static_cast<long>(ceil((double) lines.size() / batch)); // number of mappings required
     long b = 0;        // batch index
     //long counter = 0;  // number of lines processed
     std::vector<std::thread> mapThreads;
@@ -252,19 +252,13 @@ void countWords(std::deque<std::string>& lines, bool inplace, int m, int batch) 
     printProgress(0, maps, true);
 
     //for (int i = 0; (i + batch - 1) < size; i += batch) {
-    unsigned int core = std::thread::hardware_concurrency();
+    int core = std::thread::hardware_concurrency();
     core = (core > 4) ? core : 4;
 
     for (int i = 0; i < core; ++i) {
         mapThreads.emplace_back([maps, batch, &b, &lines, &mapper]() {
             try {
                 mapRoutine(maps, batch, b, lines, mapper);
-            }
-            catch (const std::system_error& e) {
-                std::cout << e.what() << " (" << e.code() << ")" << std::endl;
-            }
-            catch (const std::ios_base::failure& e) {
-                std::cout << e.what() << '\n';
             }
             catch (const std::exception& e) {
                 std::cout << e.what() << std::endl;
@@ -335,9 +329,6 @@ void countWords(std::deque<std::string>& lines, bool inplace, int m, int batch) 
             threads.emplace_back([m, output, &mx, &in, &out, &i_key, &o_key]() {
                 try {
                     mergeRoutine(m, output, mx, in, out, i_key, o_key);
-                }
-                catch (const std::system_error& e) {
-                    std::cout << e.what() << " (" << e.code() << ")" << std::endl;
                 }
                 catch (const std::ios_base::failure& e) {
                     std::cout << e.what() << '\n';

--- a/src_for_visualstudio/DatabaseSystemProject/DatabaseSystemProject/main.cpp
+++ b/src_for_visualstudio/DatabaseSystemProject/DatabaseSystemProject/main.cpp
@@ -1,4 +1,5 @@
-﻿#include <iostream>
+﻿#include <filesystem>
+#include <iostream>
 #include <fstream>
 #include <cstdlib>
 #include <windows.h>
@@ -6,6 +7,8 @@
 #include "WordCount.hpp"
 #include "Profiler.hpp"
 #include "Utility.hpp"
+
+namespace fs = std::filesystem;
 
 bool getFileNameFromDialog(std::wstring& outFilename) {
     wchar_t filename[MAX_PATH] = { 0 };
@@ -33,10 +36,9 @@ int run() {
     std::wcin.imbue(locale);        // Apply locale to wcin
     SetConsoleOutputCP(CP_UTF8);    // Apply locale to console
 
-
     // Prompt to select a file
     std::wstring inputFilename;
-    std::cout << "Please select a file." << std::endl;
+    std::cout << "Please select a file..." << std::endl;
 
     if (!getFileNameFromDialog(inputFilename)) {
         std::cout << "No file was selected." << std::endl;
@@ -44,8 +46,14 @@ int run() {
     }
 
     auto lines = getFileLines(inputFilename);
-    std::cout << lines.size() << " lines of text found!" << std::endl;
-
+    auto filename = fs::path(inputFilename).filename().string();
+    auto space = filename.length();
+    size_t size = fs::file_size(inputFilename);
+    
+    // Print file info
+    std::cout << std::endl;
+    std::cout << std::setw(space) << "File name" << std::setw(16) << "File size" << std::setw(12) << "Lines" << std::endl;
+    std::cout << std::setw(space) << filename << std::setw(16) << toBytesFormat(size) << std::setw(12) << lines.size() << std::endl;
 
     // Prompt to select batch size
     int batch = 0;
@@ -55,7 +63,6 @@ int run() {
         std::cout << "Batch size: ";
         std::cin >> batch;
     }
-
 
     // Prompt to select sorting algorithm
     int mode = 0;


### PR DESCRIPTION
## 개선사항
- 쓰레드 개수를 제한하여 CPU 오버헤드 감소
  - 매핑 성능이 더 빨라짐
  - 리듀스(런 합병) 속도는 감소했지만, 운영체제 파일 스트림 제한에 걸려 I/O 오류가 발생하던 문제 해결
- 선택한 파일의 크기, 이름, 라인 수 출력

## 성능
- 파일 700MB / 배치 1만 / i7 12700K / DDR4 32GB / M.2 NVME 512GB
  - 연산 시간: 6분 3초
![700MB_B10K](https://github.com/hsgo2430/DatabaseSystemProject/assets/9482578/09f9ff25-5704-4ad5-9d9d-9d7c7be42353)

- 파일 700MB / 배치 5만 / i7 12700K / DDR4 32GB / M.2 NVME 512GB
  - 연산 시간: 2분 2초
![700MB_B50K](https://github.com/hsgo2430/DatabaseSystemProject/assets/9482578/be9a212e-ad60-45cc-bdef-32db222c5a45)

## 비고사항
- 이전 버전보다 배치 크기를 높여야 성능 향상 체감이 가능합니다.
- 배치 크기가 작으면 연산시간이 이전보다 늘어납니다.